### PR TITLE
Load dom-ruler via npm instead of bower

### DIFF
--- a/addon/system/orientation.js
+++ b/addon/system/orientation.js
@@ -68,7 +68,7 @@ export default Ember.Object.extend({
 
     // Always unshift slide constraints,
     // since they should be handled first
-    get(this, 'constraints').unshiftObjects(constraint);
+    get(this, 'constraints').unshiftObject(constraint);
 
     return this;
   },

--- a/app/initializers/pop-over.js
+++ b/app/initializers/pop-over.js
@@ -1,6 +1,5 @@
 import Ember from "ember";
 import Flow from "ember-pop-over/system/flow";
-import config from "../config/environment";
 import * as flows from "../flows";
 
 const get = Ember.get;
@@ -11,16 +10,6 @@ export var initialize = function (app) {
     if (flowName == 'default') { return; }
     let constraints = get(flows[flowName].call(Flow.create()), 'constraints');
     app.register(`pop-over-constraint:${flowName}`, constraints, { instantiate: false });
-  });
-
-  // Set flags for integrations with other addons
-  // At least during testing, `require.entries` is null / undefined, causing
-  // the initializer to fail. We need to guard against that.
-  let entries = require.entries || {};
-  let includedModules = Ember.A(keys(entries));
-  Ember.A(['liquid-fire']).forEach(function (moduleName) {
-    let includesIntegration = includedModules.contains(moduleName);
-    app.register(`pop-over-integrations:${moduleName}`, includesIntegration, { instantiate: false });
   });
 };
 

--- a/blueprints/ember-pop-over/index.js
+++ b/blueprints/ember-pop-over/index.js
@@ -1,6 +1,0 @@
-module.exports = {
-  normalizeEntityName: function() {},
-  afterInstall: function() {
-    return this.addBowerPackageToProject('dom-ruler', '0.1.13');
-  }
-};

--- a/bower.json
+++ b/bower.json
@@ -11,8 +11,7 @@
     "ember-resolver": "~0.1.18",
     "jquery": "^1.11.3",
     "loader.js": "ember-cli/loader.js#3.2.1",
-    "qunit": "~1.18.0",
-    "dom-ruler": "~0.1.13"
+    "qunit": "~1.18.0"
   },
   "resolutions": {
     "ember": "2.1.0"

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -6,11 +6,5 @@ module.exports = function(defaults) {
     // Add options here
   });
 
-  app.import('bower_components/dom-ruler/dist/dom-ruler.amd.js', {
-    exports: {
-      'dom-ruler': ['default']
-    }
-  });
-
   return app.toTree();
 };

--- a/index.js
+++ b/index.js
@@ -1,8 +1,18 @@
+/* global node: true */
 module.exports = {
   name: 'ember-pop-over',
+  options: {
+    nodeAssets: {
+      'dom-ruler': {
+        srcDir: 'dist/amd',
+        import: ['dom-ruler.js']
+      }
+    }
+  },
+
   included: function (app) {
-    this._super.included(app);
-    app.import('bower_components/dom-ruler/dist/dom-ruler.amd.js', {
+    this._super.included.apply(this, arguments);
+    app.import('vendor/dom-ruler/dom-ruler.js', {
       exports: {
         'dom-ruler': ['default']
       }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,9 @@
     "pop-over"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.3"
+    "dom-ruler": "^0.2.4",
+    "ember-cli-babel": "^5.1.3",
+    "ember-cli-node-assets": "^0.1.6"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
Bower is deprecated and caused warnings in the discussions-front-end.